### PR TITLE
handle non-200 status from contentsgarten

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "dev",
+      "problemMatcher": [],
+      "label": "npm: dev",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/src/components/contentRenderer.astro
+++ b/src/components/contentRenderer.astro
@@ -6,12 +6,13 @@ import { customComponents } from './markdown/customComponents'
 
 export interface Props {
   content: string
+  pageRef: string
 }
 ---
 
 <Html
   className="prose mx-auto max-w-6xl"
   html={Astro.props.content}
-  renderLink={MarkdownLink}
+  renderLink={props => MarkdownLink(props, '/wiki/' + Astro.props.pageRef)}
   customComponents={customComponents}
 />

--- a/src/components/markdown/link.tsx
+++ b/src/components/markdown/link.tsx
@@ -6,8 +6,20 @@ interface Props {
   className?: string
 }
 
-export const MarkdownLink = (props: Props) => {
+export const MarkdownLink = (props: Props, currentHref: string) => {
   if (['http://', 'https://', '//'].some(o => props.href.startsWith(o)))
     return <a {...props} />
-  else return <a rel="prefetch" {...props} />
+  else
+    return (
+      <a
+        rel="prefetch"
+        {...props}
+        className={
+          (props.className || '') +
+          (currentHref === props.href
+            ? ' cursor-default font-bold text-inherit'
+            : '')
+        }
+      />
+    )
 }

--- a/src/functions/formatPageRef.ts
+++ b/src/functions/formatPageRef.ts
@@ -1,0 +1,16 @@
+const isUpper = (s: string) => s.toLowerCase() !== s
+
+export function formatPageRef(pageRef: string) {
+  return Array.from(pageRef)
+    .map((char, index, s) => {
+      const previous = s[index - 1]
+      const shouldInsertSpace = (() => {
+        if (!previous) return false
+        if ((previous === '/') !== (char === '/')) return true
+        if (isUpper(char) && !isUpper(previous)) return true
+        return false
+      })()
+      return shouldInsertSpace ? ` ${char}` : char
+    })
+    .join('')
+}

--- a/src/functions/getMarkdownFromSlug.ts
+++ b/src/functions/getMarkdownFromSlug.ts
@@ -7,7 +7,8 @@ import { contentsgarten } from '$constants/contentsgarten'
 import type { ContentsgartenOutput } from '$types/ContentsgartenOutput'
 
 type TRPCResponse = ContentsgartenOutput['view']
-interface MarkdownResponse <T = Record<string, string>> extends Omit<TRPCResponse, 'frontMatter'> {
+interface MarkdownResponse<T = Record<string, string>>
+  extends Omit<TRPCResponse, 'frontMatter'> {
   frontMatter: T
 }
 
@@ -43,12 +44,12 @@ export const getMarkdownFromSlug = async <Frontmatter = Record<string, string>>(
 
     throw new Error('cache-miss')
   } catch (e) {
-    const fetchedMarkdownResponse = await contentsgarten.view.query({
+    const fetchedMarkdownResponse = (await contentsgarten.view.query({
       pageRef: slug,
       withFile: true,
       revalidate: true,
       render: true,
-    }) as MarkdownResponse<Frontmatter>
+    })) as MarkdownResponse<Frontmatter>
 
     if (fetchedMarkdownResponse.status === 200) {
       const targetFileName = `${maxAge}.${maxAge + Date.now()}.${getHash([
@@ -68,10 +69,7 @@ export const getMarkdownFromSlug = async <Frontmatter = Record<string, string>>(
           .rm(path.join(requestedDirectory, targetFileName))
           .catch(() => {})
       }
-
-      return fetchedMarkdownResponse
-    } else {
-      return null
     }
+    return fetchedMarkdownResponse
   }
 }

--- a/src/functions/getMarkdownFromSlug.ts
+++ b/src/functions/getMarkdownFromSlug.ts
@@ -17,7 +17,7 @@ const maxAge = 60 * 1000
 
 export const getMarkdownFromSlug = async <Frontmatter = Record<string, string>>(
   slug: string
-): Promise<MarkdownResponse<Frontmatter> | null> => {
+): Promise<MarkdownResponse<Frontmatter>> => {
   // get file hash
   const now = Date.now()
   const cacheKey = getHash(['wiki', slug])

--- a/src/layouts/wiki.astro
+++ b/src/layouts/wiki.astro
@@ -102,7 +102,7 @@ const { title, contents, events, metadata, type = 'page' } = Astro.props
       </div>
     </div>
     <div
-      class="col-span-1 px-12 py-10 sm:col-span-2 md:col-span-3 xl:col-span-4"
+      class="col-span-1 px-6 md:px-12 py-10 sm:col-span-2 md:col-span-3 xl:col-span-4"
     >
       <slot />
     </div>

--- a/src/pages/event/[eventId].astro
+++ b/src/pages/event/[eventId].astro
@@ -15,9 +15,8 @@ if (eventId === undefined) {
   return rewrite(404, `${Astro.url.origin}/404`)
 }
 
-const markdown = await getMarkdownFromSlug<EventFrontmatter>(
-  `Events/${eventId}`
-)
+const pageRef = `Events/${eventId}`
+const markdown = await getMarkdownFromSlug<EventFrontmatter>(pageRef)
 
 if (markdown === null) {
   const { rewrite } = await import('$functions/rewrite')
@@ -47,5 +46,5 @@ const { rendered, lastModified, lastModifiedBy, frontMatter } = markdown
     hosts: frontMatter.hosts,
   }}
 >
-  <ContentRenderer content={rendered!.html} />
+  <ContentRenderer content={rendered!.html} pageRef={pageRef} />
 </WikiLayout>

--- a/src/pages/wiki/[...pageRef].astro
+++ b/src/pages/wiki/[...pageRef].astro
@@ -1,6 +1,7 @@
 ---
 import dayjs from 'dayjs'
 
+import BaseLayout from '$layouts/base.astro'
 import WikiLayout from '$layouts/wiki.astro'
 import ContentRenderer from '$components/contentRenderer.astro'
 
@@ -14,25 +15,46 @@ else if (pageRef.startsWith('Events/'))
   return Astro.redirect(`/event/${pageRef.replace('Events/', '')}`)
 
 const markdown = await getMarkdownFromSlug(pageRef)
+const { status, targetPageRef, rendered, lastModified, lastModifiedBy } =
+  markdown
 
-if (markdown === null) {
-  const { rewrite } = await import('$functions/rewrite')
-  return rewrite(404, `${Astro.url.origin}/404`)
+if (
+  status === 301 &&
+  targetPageRef &&
+  Astro.url.searchParams.get('redirect') !== 'no'
+) {
+  Astro.response.status = 301
+  Astro.response.headers.set('Location', `/wiki/${targetPageRef}`)
+} else if (status === 404) {
+  Astro.response.status = 404
+} else if (status === 500) {
+  Astro.response.status = 500
 }
-
-const { rendered, lastModified, lastModifiedBy } = markdown
 ---
 
-<WikiLayout
-  type="page"
-  title={pageRef as string}
-  contents={rendered!.headings}
-  metadata={{
-    edited: {
-      at: dayjs(lastModified).toDate(),
-      by: (lastModifiedBy ?? ['System']).map(o => '@' + o).join(' '),
-    },
-  }}
->
-  <ContentRenderer content={rendered!.html} />
-</WikiLayout>
+{
+  status === 200 ? (
+    <WikiLayout
+      type="page"
+      title={pageRef as string}
+      contents={rendered!.headings}
+      metadata={{
+        edited: {
+          at: dayjs(lastModified).toDate(),
+          by: (lastModifiedBy ?? ['System']).map(o => '@' + o).join(' '),
+        },
+      }}
+    >
+      <ContentRenderer content={rendered!.html} />
+    </WikiLayout>
+  ) : (
+    <BaseLayout>
+      <div class="px-6 pb-10">
+        <div class="mx-auto max-w-6xl">
+          <h1 class="mb-8 text-3xl">{pageRef}</h1>
+        </div>
+        <ContentRenderer content={rendered!.html} />
+      </div>
+    </BaseLayout>
+  )
+}

--- a/src/pages/wiki/[...pageRef].astro
+++ b/src/pages/wiki/[...pageRef].astro
@@ -6,6 +6,7 @@ import WikiLayout from '$layouts/wiki.astro'
 import ContentRenderer from '$components/contentRenderer.astro'
 
 import { getMarkdownFromSlug } from '$functions/getMarkdownFromSlug'
+import { formatPageRef } from '$functions/formatPageRef'
 
 let { pageRef } = Astro.params
 
@@ -15,8 +16,14 @@ else if (pageRef.startsWith('Events/'))
   return Astro.redirect(`/event/${pageRef.replace('Events/', '')}`)
 
 const markdown = await getMarkdownFromSlug(pageRef)
-const { status, targetPageRef, rendered, lastModified, lastModifiedBy } =
-  markdown
+const {
+  status,
+  targetPageRef,
+  rendered,
+  lastModified,
+  lastModifiedBy,
+  frontMatter,
+} = markdown
 
 if (
   status === 301 &&
@@ -36,7 +43,7 @@ if (
   status === 200 ? (
     <WikiLayout
       type="page"
-      title={pageRef as string}
+      title={frontMatter.title || formatPageRef(pageRef as string)}
       contents={rendered!.headings}
       metadata={{
         edited: {
@@ -45,7 +52,7 @@ if (
         },
       }}
     >
-      <ContentRenderer content={rendered!.html} />
+      <ContentRenderer content={rendered!.html} pageRef={pageRef} />
     </WikiLayout>
   ) : (
     <BaseLayout>
@@ -53,7 +60,7 @@ if (
         <div class="mx-auto max-w-6xl">
           <h1 class="mb-8 text-3xl">{pageRef}</h1>
         </div>
-        <ContentRenderer content={rendered!.html} />
+        <ContentRenderer content={rendered!.html} pageRef={pageRef} />
       </div>
     </BaseLayout>
   )


### PR DESCRIPTION
This PR makes the website correctly handle the cases where status is not 200.

- Status 301 - If `targetPageRef` exists, redirect there.

- Status 404 — Just set the HTTP response code and render as normal. This is because the rendered content can have helpful hints, for example, it corrects the capitalization of text.

  <img width="944" alt="image" src="https://user-images.githubusercontent.com/193136/234885701-5bb8fb62-c538-41c1-a5a9-e099ceb3414d.png">

- Status 500 — Just set the HTTP response code and render as normal. This is because the rendered content provides the reason why the page failed to render, which helps in debugging.

Also

- Improved rendering of the title of the page. Since page title is capitalized, some spaces are added.

- Links to the same page is now rendered as black bold text.

![image](https://user-images.githubusercontent.com/193136/234890986-6ea5a903-513e-4f38-b3cf-a82c549a7e80.png)

