### PR TITLE
oauth state

### DIFF
--- a/src/pages/auth/callback.astro
+++ b/src/pages/auth/callback.astro
@@ -1,12 +1,14 @@
 ---
-const state = Astro.url.searchParams.get('state')
+const state = String(Astro.url.searchParams.get('state')).replace(/^\w+!/, '')
 const code = Astro.url.searchParams.get('code')
 
 if (state === 'local' && import.meta.env.PROD) {
-  return Astro.redirect(`http://localhost:3000/auth/callback?${new URLSearchParams({
-    code: code ?? '',
-    state: state ?? '',
-  }).toString()}`)
+  return Astro.redirect(
+    `http://localhost:3000/auth/callback?${new URLSearchParams({
+      code: code ?? '',
+      state: state ?? '',
+    }).toString()}`
+  )
 }
 ---
 

--- a/src/pages/auth/login.ts
+++ b/src/pages/auth/login.ts
@@ -2,17 +2,18 @@ import CSRF from 'csrf'
 
 import type { APIRoute } from 'astro'
 
-export const get: APIRoute = async ({ redirect }) => {
+export const get: APIRoute = async ({ request, redirect }) => {
   const csrfInstance = new CSRF()
   const csrfToken = csrfInstance.create(process.env.CSRF_SECRET ?? '')
-
+  const redirectHint =
+    new URL(request.url).hostname === 'localhost' ? 'localhost3000' : 'new'
   const loginURI = `https://www.eventpop.me/oauth/authorize?${new URLSearchParams(
     {
       client_id: import.meta.env.EVENTPOP_CLIENT_ID ?? '',
       redirect_uri:
         'https://dtinth.github.io/oauth_gateway/eventpop_callback.html',
       response_type: 'code',
-      state: import.meta.env.PROD ? csrfToken : 'local'
+      state: redirectHint + '!' + (import.meta.env.PROD ? csrfToken : 'local'),
     }
   ).toString()}`
 


### PR DESCRIPTION
When redirect, need to add some redirection hint to `state=` parameter, so `oauth_gateway` knows how to redirect back to the app correctly.

- `state` begins with `new!` &rarr; `https://new.creatorsgarten.org`
- `state` begins with `localhost3000!` &rarr; `http://localhost:3000`
