### PR TITLE
Extract response logic from individual components into a view model and fix 404 error

### DIFF
--- a/src/components/wiki.astro
+++ b/src/components/wiki.astro
@@ -1,6 +1,8 @@
 ---
-import { Icon } from 'react-iconify-icon-wrapper'
+import type { WikiPageViewModel } from '$functions/wiki/getWikiPageViewModel'
 import BaseLayout from '$layouts/base.astro'
+import '@fontsource-variable/inter'
+import { Icon } from 'react-iconify-icon-wrapper'
 import ContentRenderer from './contentRenderer.astro'
 import Head from './head.astro'
 import WikiEditor from './wiki/editor.astro'
@@ -8,105 +10,48 @@ import WikiUpdateChecker from './wiki/updateChecker'
 import WikiView from './wiki/view.astro'
 import WikiViewShortcuts from './wiki/viewShortcuts.svelte'
 
-import {
-  getContentHash,
-  getMarkdownFromSlug,
-} from '$functions/wiki/getMarkdownFromSlug'
-import { formatPageRef } from '$functions/wiki/formatPageRef'
-import { getWikiDescription } from '$functions/wiki/getWikiDescription'
-import { parseFrontMatter } from '$functions/parseFrontMatter'
-import { fromZodError } from 'zod-validation-error'
-
-import type { z } from 'zod'
-import type { frontMatterSchema } from '$functions/parseFrontMatter'
-
-import '@fontsource-variable/inter'
-
 export interface Props {
-  pageRef: string
-  mode?: 'view' | 'editor'
+  viewModel: WikiPageViewModel
 }
 
-let { pageRef, mode = 'view' } = Astro.props
-
-const markdown = await getMarkdownFromSlug<
-  z.infer<typeof frontMatterSchema>['event'] & { title: string }
->(pageRef)
-const {
-  status,
-  targetPageRef,
-  rendered,
-  lastModified,
-  lastModifiedBy,
-  frontMatter,
-  file,
-  perf,
-} = markdown
-
-if (
-  status === 301 &&
-  targetPageRef &&
-  Astro.url.searchParams.get('redirect') !== 'no'
-) {
-  Astro.response.status = 301
-  Astro.response.headers.set('Location', `/wiki/${targetPageRef}`)
-} else if (status === 404) {
-  Astro.response.status = 404
-} else if (status === 500) {
-  Astro.response.status = 500
-}
-
-const frontMatterParsingResult = parseFrontMatter(frontMatter)
-const parsedFrontMatter = frontMatterParsingResult.success
-  ? frontMatterParsingResult.data
-  : undefined
-
-const title =
-  frontMatter.title ||
-  parsedFrontMatter?.event?.name ||
-  formatPageRef(pageRef as string)
-const editable = !!file
-const editing = mode === 'editor' && editable ? file : null
-const contentHash = getContentHash(markdown)
+const { head, body, perf } = Astro.props.viewModel
 ---
 
 <Head
-  title={mode === 'view' ? title : 'Editor'}
-  description={getWikiDescription(rendered?.html)}
-  ogImage={`https://screenshot.source.in.th/image/_/creatorsgarten-new-wiki/${pageRef}`}
+  title={head.title}
+  description={head.description}
+  ogImage={head.ogImage}
 />
 
 {
-  status === 200 || editing ? (
+  body.mode === 'editor' || body.mode === 'view' ? (
     <WikiView
-      pageRef={pageRef}
-      title={title}
-      rendered={rendered!}
-      parsedFrontMatter={parsedFrontMatter}
-      lastModified={lastModified}
-      lastModifiedBy={lastModifiedBy}
-      editable={editable}
+      pageRef={body.pageRef}
+      title={body.title}
+      headings={body.headings}
+      parsedFrontMatter={body.parsedFrontMatter}
+      lastModified={body.lastModified}
+      lastModifiedBy={body.lastModifiedBy}
+      editable={body.editable}
     >
-      {editing ? (
-        <WikiEditor pageRef={pageRef} file={editing} />
+      {body.mode === 'editor' ? (
+        <WikiEditor pageRef={body.pageRef} file={body.file} />
       ) : (
         <Fragment>
-          {!frontMatterParsingResult.success && (
+          {body.validationError ? (
             <div class="relative mb-8 rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700">
               <strong class="mr-2 font-bold">Invalid front matter:</strong>
-              <span class="block sm:inline">
-                {fromZodError(frontMatterParsingResult.error)}
-              </span>
+              <span class="block sm:inline">{body.validationError}</span>
             </div>
-          )}
-          <ContentRenderer content={rendered!.html} pageRef={pageRef} />
+          ) : null}
+          <ContentRenderer content={body.html} pageRef={body.pageRef} />
           <WikiUpdateChecker
-            initialContentHash={contentHash}
-            pageRef={pageRef}
+            initialContentHash={body.contentHash}
+            pageRef={body.pageRef}
             client:idle
           />
-          {!!file ? (
-            <WikiViewShortcuts path={file.path} client:only="svelte" />
+          {body.filePath ? (
+            <WikiViewShortcuts path={body.filePath} client:only="svelte" />
           ) : null}
         </Fragment>
       )}
@@ -115,12 +60,12 @@ const contentHash = getContentHash(markdown)
     <BaseLayout>
       <div class="px-6 pb-10">
         <div class="relative mx-auto max-w-6xl">
-          <h1 class="mb-8 text-3xl">{pageRef}</h1>
-          <ContentRenderer content={rendered!.html} pageRef={pageRef} />
-          {editable && (
+          <h1 class="mb-8 text-3xl">{body.pageRef}</h1>
+          <ContentRenderer content={body.html} pageRef={body.pageRef} />
+          {body.editable && (
             <div class="mt-8 flex">
               <a
-                href={`/wiki/${pageRef}/editor`}
+                href={`/wiki/${body.pageRef}/editor`}
                 data-js="wiki-edit-link"
                 class="inline-flex items-center space-x-2"
               >
@@ -130,12 +75,12 @@ const contentHash = getContentHash(markdown)
             </div>
           )}
           <WikiUpdateChecker
-            initialContentHash={contentHash}
-            pageRef={pageRef}
+            initialContentHash={body.contentHash}
+            pageRef={body.pageRef}
             client:idle
           />
-          {!!file ? (
-            <WikiViewShortcuts path={file.path} client:only="svelte" />
+          {body.filePath ? (
+            <WikiViewShortcuts path={body.filePath} client:only="svelte" />
           ) : null}
         </div>
       </div>

--- a/src/components/wiki/view.astro
+++ b/src/components/wiki/view.astro
@@ -1,9 +1,8 @@
 ---
-import Layout from '$layouts/wiki.astro'
 import CFImage from '$components/cfImage.astro'
+import Layout from '$layouts/wiki.astro'
 import SidebarContentsSection from './sidebarContentsSection.astro'
 import SidebarEventSection from './sidebarEventSection.astro'
-import SidebarShareSection from './sidebarShareSection.astro'
 import SidebarMetadataSection, {
   type Props as MetadataProps,
 } from './sidebarMetadataSection.astro'
@@ -16,7 +15,7 @@ import type { ContentsgartenOutput } from '$types/ContentsgartenOutput'
 export interface Props {
   pageRef: string
   title: string
-  rendered: NonNullable<ContentsgartenOutput['view']['rendered']>
+  headings: NonNullable<ContentsgartenOutput['view']['rendered']>['headings']
   parsedFrontMatter?: FrontMatter
   lastModified?: string
   lastModifiedBy?: string[]
@@ -26,7 +25,7 @@ export interface Props {
 const {
   pageRef,
   title,
-  rendered,
+  headings,
   parsedFrontMatter,
   lastModified,
   lastModifiedBy,
@@ -87,7 +86,7 @@ const coverImage =
   </Fragment>
 
   <Fragment slot="sidebar-left-at-least-2-columns">
-    <SidebarContentsSection contents={rendered.headings} />
+    <SidebarContentsSection contents={headings} />
   </Fragment>
 
   <Fragment slot="sidebar-right">

--- a/src/functions/wiki/getWikiPageViewModel.ts
+++ b/src/functions/wiki/getWikiPageViewModel.ts
@@ -97,10 +97,12 @@ export async function getWikiPageViewModel(input: {
   } else if (status === 404) {
     responseActions.push(response => {
       response.status = 404
+      response.headers.set('X-Astro-Reroute', 'no')
     })
   } else if (status === 500) {
     responseActions.push(response => {
       response.status = 500
+      response.headers.set('X-Astro-Reroute', 'no')
     })
   }
 

--- a/src/functions/wiki/getWikiPageViewModel.ts
+++ b/src/functions/wiki/getWikiPageViewModel.ts
@@ -1,0 +1,183 @@
+import {
+  parseFrontMatter,
+  type FrontMatter,
+  type frontMatterSchema,
+} from '$functions/parseFrontMatter'
+import type { ContentsgartenOutput } from '$types/ContentsgartenOutput'
+import type { AstroGlobal } from 'astro'
+import type { z } from 'zod'
+import { fromZodError, type ValidationError } from 'zod-validation-error'
+import { formatPageRef } from './formatPageRef'
+import { getContentHash, getMarkdownFromSlug } from './getMarkdownFromSlug'
+import { getWikiDescription } from './getWikiDescription'
+
+export interface WikiPageViewModel {
+  respond: (response: AstroGlobal['response']) => void
+  head: {
+    title: string
+    description: string | undefined
+    ogImage: string
+  }
+  body: EditorMode | ViewMode | SimpleMode
+  perf: string[]
+}
+
+/** Common info between editor mode and view mode */
+export interface PageInfo {
+  pageRef: string
+  contentHash: string
+  title: string
+  headings: NonNullable<ContentsgartenOutput['view']['rendered']>['headings']
+  parsedFrontMatter?: FrontMatter
+  lastModified?: string
+  lastModifiedBy?: string[]
+  editable: boolean
+}
+
+export interface EditorMode extends PageInfo {
+  mode: 'editor'
+  file: EditingFile
+}
+
+export interface ViewMode extends PageInfo {
+  mode: 'view'
+  validationError?: ValidationError
+  html: string
+  filePath: string | undefined
+}
+
+export interface SimpleMode {
+  mode: 'simple'
+  pageRef: string
+  html: string
+  contentHash: string
+  filePath: string | undefined
+  editable: boolean
+}
+
+export interface EditingFile {
+  path: string
+  content: string
+  revision?: string | undefined
+}
+
+export async function getWikiPageViewModel(input: {
+  pageRef: string
+  mode: 'view' | 'editor'
+  searchParams: URLSearchParams
+}): Promise<WikiPageViewModel> {
+  const { pageRef, mode, searchParams } = input
+
+  const markdown = await getMarkdownFromSlug<
+    z.infer<typeof frontMatterSchema>['event'] & { title: string }
+  >(pageRef)
+
+  const {
+    status,
+    targetPageRef,
+    rendered,
+    lastModified,
+    lastModifiedBy,
+    frontMatter,
+    file,
+    perf,
+  } = markdown
+
+  let responseActions: ((response: AstroGlobal['response']) => void)[] = []
+
+  if (
+    status === 301 &&
+    targetPageRef &&
+    searchParams.get('redirect') !== 'no'
+  ) {
+    responseActions.push(response => {
+      response.status = 301
+      response.headers.set('Location', `/wiki/${targetPageRef}`)
+    })
+  } else if (status === 404) {
+    responseActions.push(response => {
+      response.status = 404
+    })
+  } else if (status === 500) {
+    responseActions.push(response => {
+      response.status = 500
+    })
+  }
+
+  const frontMatterParsingResult = parseFrontMatter(frontMatter)
+  const parsedFrontMatter = frontMatterParsingResult.success
+    ? frontMatterParsingResult.data
+    : undefined
+
+  const pageTitle =
+    frontMatter.title ||
+    parsedFrontMatter?.event?.name ||
+    formatPageRef(pageRef as string)
+  const title = mode === 'view' ? pageTitle : 'Editor'
+  const description = getWikiDescription(rendered?.html)
+  const editable = !!file
+  const editing = mode === 'editor' && editable ? file : null
+  const contentHash = getContentHash(markdown)
+  const ogImage = `https://screenshot.source.in.th/image/_/creatorsgarten-new-wiki/${pageRef}`
+
+  let body: WikiPageViewModel['body']
+
+  if (status === 200 || editing) {
+    const commonProps: PageInfo = {
+      pageRef,
+      contentHash,
+      title: pageTitle,
+      headings: rendered?.headings || [],
+      parsedFrontMatter,
+      lastModified,
+      lastModifiedBy,
+      editable,
+    }
+    if (editing) {
+      body = {
+        ...commonProps,
+        mode: 'editor',
+        file: editing,
+      }
+    } else {
+      const validationError = frontMatterParsingResult.success
+        ? undefined
+        : fromZodError(frontMatterParsingResult.error)
+      const html = rendered?.html || ''
+      const filePath = file?.path
+      body = {
+        ...commonProps,
+        mode: 'view',
+        html,
+        validationError,
+        filePath,
+      }
+    }
+  } else {
+    const html = rendered?.html || ''
+    const filePath = file?.path
+    body = {
+      mode: 'simple',
+      pageRef,
+      contentHash,
+      html,
+      filePath,
+      editable,
+    }
+  }
+
+  return {
+    respond: response => {
+      for (const action of responseActions) {
+        action(response)
+      }
+    },
+    head: {
+      title,
+      description,
+      ogImage,
+    },
+    body,
+    perf,
+  }
+}

--- a/src/pages/event/[eventId].astro
+++ b/src/pages/event/[eventId].astro
@@ -1,7 +1,14 @@
 ---
 import Wiki from '$components/wiki.astro'
+import { getWikiPageViewModel } from '$functions/wiki/getWikiPageViewModel'
 
 let { eventId } = Astro.params
+const viewModel = await getWikiPageViewModel({
+  pageRef: `Events/${eventId}`,
+  mode: 'view',
+  searchParams: Astro.url.searchParams,
+})
+viewModel.respond(Astro.response)
 ---
 
-<Wiki pageRef={`Events/${eventId}`} />
+<Wiki viewModel={viewModel} />

--- a/src/pages/ring.astro
+++ b/src/pages/ring.astro
@@ -1,5 +1,13 @@
 ---
 import Wiki from '$components/wiki.astro'
+import { getWikiPageViewModel } from '$functions/wiki/getWikiPageViewModel'
+
+const viewModel = await getWikiPageViewModel({
+  pageRef: 'Ring',
+  mode: 'view',
+  searchParams: Astro.url.searchParams,
+})
+viewModel.respond(Astro.response)
 ---
 
-<Wiki pageRef="Ring" />
+<Wiki viewModel={viewModel} />

--- a/src/pages/wiki/[...pageRef]/editor.astro
+++ b/src/pages/wiki/[...pageRef]/editor.astro
@@ -1,5 +1,6 @@
 ---
 import Wiki from '$components/wiki.astro'
+import { getWikiPageViewModel } from '$functions/wiki/getWikiPageViewModel'
 import { updateWiki } from '$functions/wiki/updateWiki'
 
 let { pageRef } = Astro.params
@@ -47,6 +48,13 @@ if (Astro.request.method === 'POST') {
     )
   }
 }
+
+const viewModel = await getWikiPageViewModel({
+  pageRef,
+  mode: 'editor',
+  searchParams: Astro.url.searchParams,
+})
+viewModel.respond(Astro.response)
 ---
 
-<Wiki mode="editor" pageRef={pageRef} />
+<Wiki viewModel={viewModel} />

--- a/src/pages/wiki/[...pageRef]/index.astro
+++ b/src/pages/wiki/[...pageRef]/index.astro
@@ -1,5 +1,6 @@
 ---
 import Wiki from '$components/wiki.astro'
+import { getWikiPageViewModel } from '$functions/wiki/getWikiPageViewModel'
 
 let { pageRef } = Astro.params
 
@@ -10,6 +11,13 @@ else if (pageRef === 'MainPage') return Astro.redirect('/wiki' + search)
 else if (pageRef === 'Ring') return Astro.redirect('/ring' + search)
 else if (pageRef.startsWith('Events/'))
   return Astro.redirect(`/event/${pageRef.replace('Events/', '')}${search}`)
+
+const viewModel = await getWikiPageViewModel({
+  pageRef,
+  mode: 'view',
+  searchParams: Astro.url.searchParams,
+})
+viewModel.respond(Astro.response)
 ---
 
-<Wiki pageRef={pageRef} />
+<Wiki viewModel={viewModel} />


### PR DESCRIPTION
Problem

1. We currently set response attributes in component level, which [is not supported by Astro](https://docs.astro.build/en/guides/server-side-rendering/#on-demand-rendering-features)

    <img width="741" alt="image" src="https://github.com/creatorsgarten/creatorsgarten.org/assets/193136/2b6e6d52-3c3e-4232-98ee-e4a2a54e9e5f">

    - Fix by extracting most of the important logic into `getWikiPageViewModel` function. This also gives us an [anti-corruption layer](https://learn.microsoft.com/en-us/azure/architecture/patterns/anti-corruption-layer#solution) against Astro’s API.

2. Going to a nonexistent page, https://creatorsgarten.org/wiki/Meow, gives a blank page instead of our page.

    <img width="854" alt="image" src="https://github.com/creatorsgarten/creatorsgarten.org/assets/193136/8b3c4599-749f-40f3-aca5-6c490f5bc5c4">

    - Fix by using the undocumented `X-Astro-Reroute` header.