### PR TITLE
Add notice below transcript heading

### DIFF
--- a/src/layouts/base.css
+++ b/src/layouts/base.css
@@ -17,23 +17,7 @@
 }
 
 .prose {
-  font-family:
-    'Basier Circle',
-    'Sarabun',
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    Roboto,
-    'Helvetica Neue',
-    Arial,
-    'Noto Sans',
-    sans-serif,
-    'Apple Color Emoji',
-    'Segoe UI Emoji',
-    'Segoe UI Symbol',
-    'Noto Color Emoji' !important;
+  @apply font-prose;
 }
 
 .prose > h1 {

--- a/src/pages/videos/[eventId]/[slug].astro
+++ b/src/pages/videos/[eventId]/[slug].astro
@@ -133,7 +133,7 @@ const transcriptUrl = `https://github.com/creatorsgarten/videos/blob/main/data/v
                 <p>
                   {transcriptLanguage === 'th' ? (
                     <span>
-                      คำบรรยายต่อไปนี้ไม่ถูกต้องทั้งหมด หากคุณพบข้อผิดพลาดใดๆ
+                      คำบรรยายต่อไปนี้อาจไม่ถูกต้องทั้งหมด หากคุณพบข้อผิดพลาดใดๆ
                       <a href={transcriptUrl} class="font-medium">
                         คุณสามารถช่วยแก้ไขข้อผิดพลาดได้บน GitHub
                       </a>

--- a/src/pages/videos/[eventId]/[slug].astro
+++ b/src/pages/videos/[eventId]/[slug].astro
@@ -24,6 +24,8 @@ if (!video) {
   })
 }
 const iframeId = `youtube-${video.youtubeId}-${eventId}-${slug}`
+const transcriptLanguage = video.transcriptRef?.endsWith('_th') ? 'th' : 'en'
+const transcriptUrl = `https://github.com/creatorsgarten/videos/blob/main/data/videos/${video.transcriptRef}.vtt`
 ---
 
 <Head title="Videos" />
@@ -127,6 +129,13 @@ const iframeId = `youtube-${video.youtubeId}-${eventId}-${slug}`
           !!video.transcriptRef && (
             <div class="p-6">
               <h2 class="mb-2 text-xl font-medium">Transcript</h2>
+              <div class="bg-yellow-100 p-4 rounded-md">
+                <p class="mb-4">
+                  {transcriptLanguage === 'th'
+                    ? <span>คำบรรยายนี้ดูแลโดยชุมชนและอาจไม่ถูกต้อง หากคุณพบข้อผิดพลาด คุณสามารถมีส่วนร่วมใน <a href={transcriptUrl}>GitHub</a>.</span>
+                    : <span>These transcripts are community maintained and may not be accurate. If you spot an error, you can contribute on <a href={transcriptUrl}>GitHub</a>.</span>}
+                </p>
+              </div>
               <VideoTranscript
                 transcriptRef={video.transcriptRef}
                 chapters={video.chapters}

--- a/src/pages/videos/[eventId]/[slug].astro
+++ b/src/pages/videos/[eventId]/[slug].astro
@@ -129,11 +129,24 @@ const transcriptUrl = `https://github.com/creatorsgarten/videos/blob/main/data/v
           !!video.transcriptRef && (
             <div class="p-6">
               <h2 class="mb-2 text-xl font-medium">Transcript</h2>
-              <div class="bg-yellow-100 p-4 rounded-md">
-                <p class="mb-4">
-                  {transcriptLanguage === 'th'
-                    ? <span>คำบรรยายนี้ดูแลโดยชุมชนและอาจไม่ถูกต้อง หากคุณพบข้อผิดพลาด คุณสามารถมีส่วนร่วมใน <a href={transcriptUrl}>GitHub</a>.</span>
-                    : <span>These transcripts are community maintained and may not be accurate. If you spot an error, you can contribute on <a href={transcriptUrl}>GitHub</a>.</span>}
+              <div class="-mx-2 mb-4 bg-yellow-500/15 p-2 font-prose text-xs font-light leading-relaxed antialiased">
+                <p>
+                  {transcriptLanguage === 'th' ? (
+                    <span>
+                      คำบรรยายต่อไปนี้ไม่ถูกต้องทั้งหมด หากคุณพบข้อผิดพลาดใดๆ
+                      <a href={transcriptUrl} class="font-medium">
+                        คุณสามารถช่วยแก้ไขข้อผิดพลาดได้บน GitHub
+                      </a>
+                    </span>
+                  ) : (
+                    <span>
+                      These community-maintained transcripts may contain
+                      inaccuracies.
+                      <a href={transcriptUrl} class="font-medium">
+                        Please submit any corrections on GitHub.
+                      </a>
+                    </span>
+                  )}
                 </p>
               </div>
               <VideoTranscript

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -24,7 +24,7 @@ module.exports = {
         ],
         prose: [
           'Basier Circle',
-          'Anuphan',
+          'Sarabun',
           ...defaultConfig.theme.fontFamily.sans,
         ],
         casual: [


### PR DESCRIPTION
Add a notice below the transcript heading informing people that the transcripts are community maintained and may not be as accurate, and let them know they can contribute on GitHub.

- Add a notice below the transcript heading in `src/pages/videos/[eventId]/[slug].astro`.
- Display the notice in English for English transcripts and Thai for Thai transcripts, determined using the ref suffix `_en` or `_th`.
- Include a link to the VTT file on GitHub for contributions.
- Style the notice in a box with yellow color.
- Put the text directly inside the markup and not in a variable.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/creatorsgarten/creatorsgarten.org?shareId=a16f988e-628a-4b6f-96f9-7f42e4aef2c4).